### PR TITLE
use controllers instead of URL detection...

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE structures SYSTEM "../../tao/doc/structures.dtd">
 <structures>
-	<structure id="help" name="Help" level="100" group="settings" binding="taoCe/controller/home">
+	<structure id="help" name="Help" level="100" group="settings" binding="taoCe/controller/help">
 		<description></description>
 		<icon id="icon-help" src=""/>
 		<sections>
-			<section id="help" name="Help" url="/taoCe/Main/index" binding="taoCe/controller/home"></section>
+			<section id="help" name="Help" url="/taoCe/Main/index" binding="taoCe/controller/help"></section>
 		</sections>
 	</structure>
 </structures>

--- a/views/js/controller/help.js
+++ b/views/js/controller/help.js
@@ -1,0 +1,27 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+define([
+    'lodash',
+    'taoCe/controller/home'
+], function(_, homeController){
+    'use strict';
+
+    return _.defaults({ entrySplash : false }, homeController);
+});

--- a/views/js/controller/home.js
+++ b/views/js/controller/home.js
@@ -1,54 +1,61 @@
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
- *               
- * 
+ *
+ *
  */
-define(['jquery', 'helpers', 'taoCe/controller/home/splash'], function($, helpers, splash){
+define([
+    'jquery',
+    'helpers',
+    'taoCe/controller/home/splash'
+], function($, helpers, splash) {
     'use strict';
 
     var $mainContainer = $('body');
 
     /**
-    * The homeController set up the splash screen.
-    * 
-    * @exports taoCe/controller/home
-    */
+     * The homeController set up the splash screen.
+     *
+     * @exports taoCe/controller/home
+     */
     var homeController = {
-        
+
+
+        entrySplash : true,
+
         /**
          * Setup the splash screen: loads it's content and initialize the component.
          */
-        start : function(){
-          
-          //the splash content is loaded only once.
-          if($('#splash-screen', $mainContainer).length === 0){
-             $.get(helpers._url('splash', 'Home', 'taoCe')).success(function(response){
-                 var $splash = $(response);
-                 $splash.css('display', 'none');
-                 $mainContainer.append($splash);
-                 
-                 
-                 splash.init();
-             });
-         } else {
-              splash.init();
-         }
+        start: function start() {
+            var self = this;
+
+            //the splash content is loaded only once.
+            if ($('#splash-screen', $mainContainer).length === 0) {
+                $.get(helpers._url('splash', 'Home', 'taoCe')).success(function(response) {
+                    var $splash = $(response);
+                    $splash.css('display', 'none');
+                    $mainContainer.append($splash);
+
+                    splash.init(self.entrySplash);
+                });
+            } else {
+                splash.init(self.entrySplash);
+            }
         }
     };
-    
+
     return homeController;
 });

--- a/views/js/controller/home/splash.js
+++ b/views/js/controller/home/splash.js
@@ -17,7 +17,7 @@
  *
  *
  */
-define(['jquery', 'helpers', 'util/url', 'taoCe/controller/home/custom-scrollbar'], function ($, helpers, urlUtil) {
+define(['jquery', 'taoCe/controller/home/custom-scrollbar'], function ($) {
     'use strict';
 
 
@@ -33,16 +33,13 @@ define(['jquery', 'helpers', 'util/url', 'taoCe/controller/home/custom-scrollbar
         /**
          * Initialize the splash screen
          */
-        init: function () {
+        init: function (isHomePage) {
 
             //console.log(this)
             this.$splashScreen = $('#splash-screen');
             var $splashWrapper = $('.splash-screen-wrapper');
             var $splashDesc = $('.desc', this.$splashScreen);
             var $splashDiagram = $('.diagram', this.$splashScreen);
-            var parsedLocation = urlUtil.parse(window.location.href);
-            var parsedIndex = urlUtil.parse(helpers._url('index', 'Main', 'taoCe'));
-            var isHomePage = parsedIndex.path === parsedLocation.path;
 
             //Url to redirect after closing
             this.redirectUrl = '';

--- a/views/js/controller/home/splash.js
+++ b/views/js/controller/home/splash.js
@@ -32,6 +32,7 @@ define(['jquery', 'taoCe/controller/home/custom-scrollbar'], function ($) {
 
         /**
          * Initialize the splash screen
+         * @param {Boolean} [isHomePage = false] - less options if not used as an entry splash
          */
         init: function (isHomePage) {
 


### PR DESCRIPTION

The splash is used in 2 context, entry splash and help. Before to resolve in which context, it was comparing the current URL. This PR set up a comp conf and dedicated controllers. 

related to on https://github.com/oat-sa/tao-core/pull/557
