### PR TITLE
Fix/solar 60/help section behind feature flag

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -18,6 +18,8 @@
  * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
  */
 
+use oat\taoCe\scripts\install\MapHelpSectionFeatureFlag;
+
 return [
     'name' => 'taoCe',
     'label' => 'Community Edition',
@@ -57,6 +59,7 @@ return [
     'install' => [
         'php' => [
             dirname(__FILE__) . '/scripts/install/overrideEntryPoint.php',
+            MapHelpSectionFeatureFlag::class
         ],
     ],
     'uninstall' => [

--- a/migrations/Version202306151234563976_taoCe.php
+++ b/migrations/Version202306151234563976_taoCe.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoCe\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\menu\SectionVisibilityFilter;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoCe\scripts\install\MapHelpSectionFeatureFlag;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202306151234563976_taoCe extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Map Help navigation Section Behind Feature Flag';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->propagate(
+            new MapHelpSectionFeatureFlag()
+        )();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $sectionVisibilityFilter = $this->getServiceManager()->get(SectionVisibilityFilter::SERVICE_ID);
+        $featureFlagSections = $sectionVisibilityFilter
+            ->getOption(SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS);
+        
+        unset($featureFlagSections['help']);
+        
+        $sectionVisibilityFilter->setOption(
+            SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS,
+            $featureFlagSections
+        );
+        
+        $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
+    }
+}

--- a/scripts/install/MapHelpSectionFeatureFlag.php
+++ b/scripts/install/MapHelpSectionFeatureFlag.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoCe\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\menu\SectionVisibilityFilter;
+
+class MapHelpSectionFeatureFlag extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $sectionVisibilityFilter = $this->getServiceManager()->get(SectionVisibilityFilter::SERVICE_ID);
+        $featureFlagSections = $sectionVisibilityFilter
+            ->getOption(SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS);
+        $featureFlagSections['help'] = ['FEATURE_FLAG_HELP_SECTION_AVAILABLE'];
+        $sectionVisibilityFilter->setOption(
+            SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS,
+            $featureFlagSections
+        );
+        $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
+    }
+}


### PR DESCRIPTION
This change allows hiding the help button based on the feature flag `FEATURE_FLAG_HELP_SECTION_AVAILABLE`.

This will add a block to SectionVisibilityFilter to control button display