### PR TITLE
fix: add uninstall scripts

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -19,6 +19,9 @@
  */
 
 use oat\taoCe\scripts\install\MapHelpSectionFeatureFlag;
+use oat\taoCe\scripts\uninstall\RemoveSectionVisibilityFilterEntry;
+use oat\taoCe\scripts\uninstall\RevertEntryPoint;
+use oat\taoCe\scripts\uninstall\UnregisterLoginController;
 
 return [
     'name' => 'taoCe',
@@ -63,6 +66,11 @@ return [
         ],
     ],
     'uninstall' => [
+        'php' => [
+            UnregisterLoginController::class,
+            RemoveSectionVisibilityFilterEntry::class,
+            RevertEntryPoint::class,
+        ]
     ],
     'routes' => [
         '' => ['class' => 'oat\\taoCe\\model\\routing\\EntryRoute'],

--- a/scripts/uninstall/RemoveSectionVisibilityFilterEntry.php
+++ b/scripts/uninstall/RemoveSectionVisibilityFilterEntry.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoCe\scripts\uninstall;
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\menu\SectionVisibilityFilter;
+
+class RemoveSectionVisibilityFilterEntry extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $sectionVisibilityFilter = $this->getServiceManager()->get(SectionVisibilityFilter::SERVICE_ID);
+        $featureFlagSections = $sectionVisibilityFilter
+            ->getOption(SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS);
+
+        unset($featureFlagSections['help']);
+        $sectionVisibilityFilter->setOption(
+            SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS,
+            $featureFlagSections
+        );
+        $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
+    }
+}

--- a/scripts/uninstall/RevertEntryPoint.php
+++ b/scripts/uninstall/RevertEntryPoint.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoCe\scripts\uninstall;
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\entryPoint\EntryPointService;
+use oat\taoBackOffice\model\entryPoint\BackOfficeEntryPoint;
+
+class RevertEntryPoint extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $this->getEntryPointService()->overrideEntryPoint('backoffice', new BackOfficeEntryPoint());
+        $this->getEntryPointService()->removeEntryPoint('guestaccess');
+        $this->getServiceManager()->register(EntryPointService::SERVICE_ID, $this->getEntryPointService());
+    }
+
+    private function getEntryPointService(): EntryPointService
+    {
+        return $this->getServiceManager()->get(EntryPointService::SERVICE_ID);
+    }
+}

--- a/scripts/uninstall/UnregisterLoginController.php
+++ b/scripts/uninstall/UnregisterLoginController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoCe\scripts\uninstall;
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\mvc\DefaultUrlService;
+
+class UnregisterLoginController extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $defaultUrlService = $this->getServiceManager()->get(DefaultUrlService::SERVICE_ID);
+        $defaultUrlServiceLoginOption = $defaultUrlService->getOption('login');
+        unset($defaultUrlServiceLoginOption['fallback']);
+        $defaultUrlServiceLoginOption['ext'] = 'tao';
+        $defaultUrlServiceLoginOption['controller'] = 'Main';
+        $defaultUrlServiceLoginOption['action'] = 'login';
+        $defaultUrlService->setOption('login', $defaultUrlServiceLoginOption);
+        $this->getServiceManager()->register(DefaultUrlService::SERVICE_ID, $defaultUrlService);
+    }
+}


### PR DESCRIPTION
This will allow uninstalling action on `taoCe`

Commnad required:
```php tao/scripts/uninstallExtension.php taoCe```

How to test it:
1. Confirm `config/generis/installation.conf.php` does not contain taoCe installed
2. Confirm `config/tao/entrypoint.conf.php` does not contain `prelogin` entry
3. Confirm `config/tao/entrypoint.conf.php` does not contain `guestaccess` entry in `existing` array
4. Confirm `config/tao/entrypoint.conf.php` does not contain `oat\taoCe\model\entryPoint\TaoCeEntrypoint()` in `backoffice` entry
